### PR TITLE
fix: Unblocking third party embeds

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -8,3 +8,6 @@ export const READ_COUNT_KEY = 'readCount';
 
 export const FETCH_CONTENT_MESSAGE = 'fetchContent';
 export const FETCH_USER_ID = 'fetchUserId';
+
+// Below keys are explicily used by medium platform to monitor user activity
+export const POST_VIEW_MONTH_COUNT_KEY = 'post-article|posts-viewed-month-count'

--- a/src/medium-unlocker.js
+++ b/src/medium-unlocker.js
@@ -2,7 +2,7 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import App from './components/App/App.jsx';
 import { getMeteredContentElement, hasMembershipPrompt, log } from './utils.js';
-import { MEMBERSHIP_PROMPT_ID } from './constants.js';
+import { MEMBERSHIP_PROMPT_ID, POST_VIEW_MONTH_COUNT_KEY } from './constants.js';
 
 let previousUrl = window.location.href;
 let loaderElement;
@@ -26,6 +26,7 @@ function registerListeners() {
 }
 
 function unlockIfHidden() {
+  _settingPostViewCount()
   if (!hasMembershipPrompt(document)) {
     log('Content is open, nothing to do');
     return;
@@ -123,6 +124,18 @@ function _showLoader() {
     document.getElementsByTagName('footer')[0].style = 'margin-top: 100px;';
   }
   return loaderElement;
+}
+
+function _settingPostViewCount(count = 0) {
+  try {
+    const initCount = localStorage.getItem(POST_VIEW_MONTH_COUNT_KEY);
+    if (initCount > 0) {
+      log('Changing posts viewed month count');
+      localStorage.setItem(POST_VIEW_MONTH_COUNT_KEY, count);
+    }
+  } catch (err) {
+
+  }
 }
 
 registerListeners();


### PR DESCRIPTION
Hey @manojVivek,  I use your extension a lot. and thanks for creating it!!
Recently I've been facing the issue where in third party embeds are not shown in certain cases. More details about this issue is described [here](https://github.com/manojVivek/medium-unlimited/issues/131). 

While tinkering with medium platform, I noticed, it uses persistent storage on client to decide when to load these embeds. For now I have found a way to circumvent this logic. 