### PR TITLE
Major Update to manually activate addon on whichever site you want

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,15 @@
   "name": "Medium Unlimited: Read paid content for free!",
   "description": "Unlocks medium.com for unlimited reads, no membership required",
   "short_name": "Medium Unlimited",
-  "version": "1.10.0",
+  "version": "1.20.0",
   "manifest_version": 2,
+  "optional_permissions": [
+		"*://*/*"
+	],
   "background": {
-    "scripts": ["background.bundle.js"]
+    "scripts": [
+      "background.bundle.js"
+    ]
   },
   "browser_action": {
     "default_icon": "static/logo_128.png",
@@ -73,7 +78,8 @@
         "https://bootcamp.uxdesign.cc/*",
         "https://*.baos.pub/*",
         "https://www.inbitcoinwetrust.net/*",
-        "https://blog.prototypr.io/*"
+        "https://blog.prototypr.io/*",
+        "https://blog.devgenius.io/*"
       ],
       "js": ["main.bundle.js"]
     }
@@ -87,6 +93,8 @@
   "permissions": [
     "webRequest",
     "webRequestBlocking",
+    "contextMenus",
+    "activeTab",
     "https://medium.com/*",
     "https://towardsdatascience.com/*",
     "https://hackernoon.com/*",
@@ -145,8 +153,7 @@
     "https://medium.datadriveninvestor.com/*",
     "https://bootcamp.uxdesign.cc/*",
     "https://*.baos.pub/*",
-    "https://www.inbitcoinwetrust.net/*",
-    "https://blog.prototypr.io/*"
+    "https://www.inbitcoinwetrust.net/*"
   ],
   "web_accessible_resources": ["static/*"]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -153,7 +153,9 @@
     "https://medium.datadriveninvestor.com/*",
     "https://bootcamp.uxdesign.cc/*",
     "https://*.baos.pub/*",
-    "https://www.inbitcoinwetrust.net/*"
+    "https://www.inbitcoinwetrust.net/*",
+    "https://blog.prototypr.io/*",
+    "https://blog.devgenius.io/*"
   ],
   "web_accessible_resources": ["static/*"]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -45,7 +45,8 @@
         "https://android.jlelse.eu/*",
         "https://robinhood.engineering/*",
         "https://blog.hipolabs.com/*",
-        "https://ux.shopify.com/*"
+        "https://ux.shopify.com/*",
+        "https://engineering.talkdesk.com/*"
       ],
       "js": ["main.bundle.js"]
     }
@@ -90,7 +91,8 @@
     "https://android.jlelse.eu/*",
     "https://robinhood.engineering/*",
     "https://blog.hipolabs.com/*",
-    "https://ux.shopify.com/*"
+    "https://ux.shopify.com/*",
+    "https://engineering.talkdesk.com/*"
   ],
   "web_accessible_resources": ["static/*"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,38 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/chrome": {
+      "version": "0.0.128",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.128.tgz",
+      "integrity": "sha512-eGc599TDtersMBW1cSnExHm0IHrXrO5xdk6Sa2Dq30ED+hR1rpT1ez0NNcCgvGO52nmktGfyvd3Uyquzv3LL4g==",
+      "requires": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "@types/filesystem": {
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.31.tgz",
+      "integrity": "sha512-9Dj1Gb7ZhknhJ8J1H/lTQrEorwIHWZlO9Tfi0WMrvyO1+2GUIUF8Sg4zrID77hj0ywArzQRJ1MwlT9H7c9QmEQ==",
+      "requires": {
+        "@types/filewriter": "*"
+      }
+    },
+    "@types/filewriter": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
+    },
+    "@types/firefox-webext-browser": {
+      "version": "82.0.0",
+      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-82.0.0.tgz",
+      "integrity": "sha512-zKHePkjMx42KIUUZCPcUiyu1tpfQXH9VR4iDYfns3HvmKVJzt/TAFT+DFVroos8BI9RH78YgF3Hi/wlC6R6cKA=="
+    },
+    "@types/har-format": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.6.tgz",
+      "integrity": "sha512-TeZjp4COiAWPOeGx1tuFJETr/SBMx80lxqeqnCC36ZVn463f7ElCdA3X9RzDuo3BHjhN4apw41A5uoIw5FzgWA=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -1892,6 +1924,16 @@
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
+    },
+    "content-scripts-register-polyfill": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/content-scripts-register-polyfill/-/content-scripts-register-polyfill-2.1.2.tgz",
+      "integrity": "sha512-0R1/aXWK0L6mWjIYeGPnAMAvxDjUqPph6I27GHFeyO+ILs6gFGfN78zrCISSqYd3rFODPY/GDK/dYQi7m5xJ7A==",
+      "requires": {
+        "@types/firefox-webext-browser": "^82.0.0",
+        "webext-patterns": "^1.0.0",
+        "webext-polyfill-kinda": "0.0.2"
+      }
     },
     "convert-source-map": {
       "version": "1.5.1",
@@ -6081,6 +6123,49 @@
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
       }
+    },
+    "webext-additional-permissions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/webext-additional-permissions/-/webext-additional-permissions-2.0.1.tgz",
+      "integrity": "sha512-K8OmXiE9QTPUVI6XKyMmV3FY8s+6DENxvRg40fzo64Mh2Kb3q+ZUPx73mnGeIiA5hfmstXdwGXULEdVD1IEYSw==",
+      "requires": {
+        "@types/chrome": "0.0.128"
+      }
+    },
+    "webext-detect-page": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-2.0.6.tgz",
+      "integrity": "sha512-IGpAHdsHz9mwpT8nHyzbdVz1ArUnsRf3PNGMprk3MgEtyN+jhcV4JqkOjNiKIb3k9sZ4WKY4lCxi5MtV1MuTYg=="
+    },
+    "webext-domain-permission-toggle": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/webext-domain-permission-toggle/-/webext-domain-permission-toggle-2.1.0.tgz",
+      "integrity": "sha512-kRpTL0K783EYCh73sJnCzYyWeiwzFI0NVzJNgnYLdJ5pJv5TOZ240QVfzsumzuOz7gJENJ1S2gdPnMvUqPNC7g==",
+      "requires": {
+        "webext-additional-permissions": "^2.0.1",
+        "webext-detect-page": "^2.0.6",
+        "webext-patterns": "^1.0.0",
+        "webext-polyfill-kinda": "^0.0.2"
+      }
+    },
+    "webext-dynamic-content-scripts": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-7.1.2.tgz",
+      "integrity": "sha512-AznyC20A/Bl3B3kzwPf1+a19oWD2vUcgVWQ2CVPTRHCgB+3QKwwMxM6L1nhmk+FIozvFGBCx+9gNPPLHyRDSaw==",
+      "requires": {
+        "content-scripts-register-polyfill": "^2.1.2",
+        "webext-additional-permissions": "^2.0.1"
+      }
+    },
+    "webext-patterns": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webext-patterns/-/webext-patterns-1.1.0.tgz",
+      "integrity": "sha512-u2xQUdengcXxBFaSy2CF89RmlQCv3SRWNW6J2+EKZPRvnRARf+UyzwVZZJJogUCgqzNhn5mswOYchnHCfh/nmA=="
+    },
+    "webext-polyfill-kinda": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-0.0.2.tgz",
+      "integrity": "sha512-Kecc1rDvsQtZJgnIAsMOQBj0WAL6v9Em42AW5EHcoute7z50lUQ2tXUfTyiydOauaT8VYK0tHYZlMWo7mlBM8g=="
     },
     "webpack": {
       "version": "4.41.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "classnames": "^2.2.6",
     "gh-pages": "^2.2.0",
     "react": "^16.4.2",
-    "react-dom": "^16.4.2"
+    "react-dom": "^16.4.2",
+    "webext-domain-permission-toggle": "^2.1.0",
+    "webext-dynamic-content-scripts": "^7.1.2"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",

--- a/src/background.js
+++ b/src/background.js
@@ -1,7 +1,13 @@
 import intercept from './request_interceptors'; //Importing just to make sure the interceptors are registered.
 import {init} from './utils';
+import 'webext-dynamic-content-scripts';
+import addDomainPermissionToggle from 'webext-domain-permission-toggle';
+import {getAdditionalPermissions, getManifestPermissions} from 'webext-additional-permissions';
+
 
 //Initialize global handlers
 init();
 
 intercept();
+
+addDomainPermissionToggle();

--- a/src/request_interceptors.js
+++ b/src/request_interceptors.js
@@ -61,6 +61,7 @@ const urlsList = [
   'https://*.baos.pub/*',
   'https://www.inbitcoinwetrust.net/*',
   'https://blog.prototypr.io/*',
+  'https://blog.devgenius.io/*'
 ];
 
 export default function intercept() {

--- a/website/index.html
+++ b/website/index.html
@@ -132,6 +132,7 @@ layout: default
       <li>https://*.baos.pub</li>
       <li>https://www.inbitcoinwetrust.net</li>
       <li>https://blog.prototypr.io</li>
+      <li>https://blog.devgenius.io/</li>
     </ul>
     <p>Please get in touch if you need any other custom medium domain supported.</p>
 


### PR DESCRIPTION
Hey guys, a long needed feature which myself wanted is now available!

I was trying for a long time to change content-scripts dynamically and include whatever site makes a call to medium's cdn. But this feature was buggy as hell and didn't always work. So, I started searching for libraries that make chrome extensions manually getting enabled. And I found them.  It was a bit of trial and error but it now plays nicely with every medium site I checked.

With the help of [webext-domain-permission-toggle](https://github.com/fregante/webext-domain-permission-toggle) and [webext-dynamic-content-scripts](https://github.com/fregante/webext-dynamic-content-scripts) you can now manually enable the extension on whichever site you want.

I checked the extension on numerous sites that there aren't on the list and it works fine.

To use the addon on an unsupported page, right click the addon's icon like shown below and select **Enable on this domain**:
![image](https://user-images.githubusercontent.com/25390905/123803285-d4476280-d8f4-11eb-8eaf-2311d6ce0e6b.png)

Press Allow for the new permissions to be applied:

![image](https://user-images.githubusercontent.com/25390905/123803372-e7f2c900-d8f4-11eb-9c36-9925df69aa7d.png)


Finally, press OK for the page to be reloaded and the article to be unlocked:

![image](https://user-images.githubusercontent.com/25390905/123803559-1375b380-d8f5-11eb-897c-49c471048659.png)

That's it, let me know what you think.

P.S. If you wanna buy my a beer here's my [paypal link](https://www.paypal.me/Ntdark)